### PR TITLE
Remove redundant ENDIF in locals_imp.abap

### DIFF
--- a/src/datamodel/zbp_acb_r_recipe.clas.locals_imp.abap
+++ b/src/datamodel/zbp_acb_r_recipe.clas.locals_imp.abap
@@ -49,7 +49,6 @@ CLASS lhc_review IMPLEMENTATION.
                           severity = if_abap_behv_message=>severity-error
                           text     = 'Keine Berechtigung zum Ändern von anderen Reviews'
                           ) ) TO reported-review.
-        ENDIF.
       ENDIF.
     ENDLOOP.
   ENDMETHOD.


### PR DESCRIPTION
Removed unnecessary ENDIF statement in locals_imp.abap.

#10